### PR TITLE
Fix formatting for "command" option

### DIFF
--- a/hcswif.py
+++ b/hcswif.py
@@ -295,7 +295,7 @@ def getCommandJobs(parsed_args, wf_name):
         job = {}
         job['name'] = wf_name + '_job' + str(len(jobs))
 
-        job['command'] = cmd
+        job['command'] = [cmd]
 
         # Add any necessary files from tape
         if parsed_args.filelist==None:


### PR DESCRIPTION
Fix minor formatting issue so the "command" option will work correctly for swif2